### PR TITLE
Fix login response to include user courses

### DIFF
--- a/server/routes/auth.js
+++ b/server/routes/auth.js
@@ -29,7 +29,8 @@ router.post('/login', async (req, res) => {
     const match = await bcrypt.compare(password, user.password);
     if (!match) return res.status(400).json({ message: 'אימייל או סיסמה שגויים' });
     const token = jwt.sign({ id: user._id, email: user.email, isAdmin: user.isAdmin }, process.env.JWT_SECRET || 'devsecret', { expiresIn: '7d' });
-    res.json({ token, user: { email: user.email, isAdmin: user.isAdmin } });
+    // include user's courses so frontend can display them after login
+    res.json({ token, user: { email: user.email, isAdmin: user.isAdmin, courses: user.courses } });
   } catch (err) {
     res.status(500).json({ message: 'שגיאת שרת' });
   }


### PR DESCRIPTION
## Summary
- return a user's course list on successful login

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6845a4f1620c8322922430740f9337ad